### PR TITLE
fix error with kirby 5.3.0

### DIFF
--- a/lib/options/imageradio-option.php
+++ b/lib/options/imageradio-option.php
@@ -4,23 +4,23 @@ namespace SylvainJule;
 
 use Kirby\Cms\ModelWithContent;
 
-
 class ImageRadioOption extends \Kirby\Option\Option {
     public function __construct(
         public string|int|float|null $value,
         public bool $disabled = false,
         public string|null $image = null,
-         public string|null $icon = null,
-		public string|array|null $info = null,
-		string|array|null $text = null
+        public string|null $icon = null,
+        public string|array|null $info = null,
+        string|array|null $text = null,
+        public bool $resolve = true
     ) {
-		$this->text = $text ?? ['en' => $this->value];
+        $this->text = $text ?? ['en' => $this->value];
     }
 
     public function render(ModelWithContent $model, bool $safeMode = true): array
     {
         return [
-            ...parent::render($model),
+            ...parent::render($model, $safeMode),
             'image' => $this->image
         ];
     }

--- a/lib/options/imageradio-option.php
+++ b/lib/options/imageradio-option.php
@@ -17,7 +17,7 @@ class ImageRadioOption extends \Kirby\Option\Option {
 		$this->text = $text ?? ['en' => $this->value];
     }
 
-    public function render(ModelWithContent $model): array
+    public function render(ModelWithContent $model, bool $safeMode = true): array
     {
         return [
             ...parent::render($model),

--- a/lib/options/imageradio-options.php
+++ b/lib/options/imageradio-options.php
@@ -3,7 +3,7 @@
 namespace SylvainJule;
 
 class ImageRadioOptions extends \Kirby\Option\Options {
-    public static function factory(array $items = []): static {
+    public static function factory(array $items = [], bool $resolve = true): static {
         $collection = new static();
 
         // We format the correct image url here ↓
@@ -27,7 +27,7 @@ class ImageRadioOptions extends \Kirby\Option\Options {
                     $option['value'] = $option;
                 }
             }
-            $option = ImageRadioOption::factory($option);
+            $option = ImageRadioOption::factory($option, $resolve);
             $collection->__set($option->id(), $option);
         }
 

--- a/lib/options/imageradio-options.php
+++ b/lib/options/imageradio-options.php
@@ -12,22 +12,27 @@ class ImageRadioOptions extends \Kirby\Option\Options {
         $baseUrl = rtrim($baseUrl, '/');
 
         foreach($items as $key => $option) {
-            $image = $items[$key]['image'];
-            if(!str_starts_with($image, 'http')) {
-                $items[$key]['image'] = $baseUrl .'/'. $items[$key]['image'];
+            if (is_array($option) && isset($option['image'])) {
+                $image = $option['image'];
+                if(!str_starts_with($image, 'http')) {
+                    $items[$key]['image'] = $baseUrl .'/'. $image;
+                }
             }
         }
 
         foreach ($items as $key => $option) {
             if (is_array($option) === false || array_key_exists('value', $option) === false) {
                 if(is_string($key)) {
-                    $option['value'] = $key;
-                }
-                else {
-                    $option['value'] = $option;
+                    if (is_array($option)) {
+                        $option['value'] = $key;  // preserve image/text/etc., just inject value
+                    } else {
+                        $option = ['value' => $key, 'text' => $option];
+                    }
+                } else {
+                    $option = ['value' => $option];
                 }
             }
-            $option = ImageRadioOption::factory($option, $resolve);
+            $option = ImageRadioOption::factory($option);
             $collection->__set($option->id(), $option);
         }
 


### PR DESCRIPTION
fixes the follwing error:
```php
Declaration of SylvainJule\ImageRadioOption::render(Kirby\Cms\ModelWithContent $model): array 
must be compatible with Kirby\Option\Option::render(Kirby\Cms\ModelWithContent $model, bool $safeMode = true): array
```